### PR TITLE
Gov Cloud Support in Cloudformation (2.2.5)

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Stack for complete deployment of Metaflow (v2.2.5)
+Description: Stack for complete deployment of Metaflow (last-updated-date 12/02/2020)
 
 Parameters:
   SagemakerInstance: 
@@ -63,7 +63,7 @@ Parameters:
     Type: String
     Default: 'aws'
     AllowedValues: ['aws', 'aws-us-gov']
-    Description: 'IAM Partition (DO NOT CHANGE THIS UNLESS YOU HAVE A VERY SPECIFIC REASON)'
+    Description: 'IAM Partition (Select aws-us-gov for AWS GovCloud, otherwise leave as is)'
 
 Mappings:
   ServiceInfo:

--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Stack for complete deployment of Metaflow (v2.0.0)
+Description: Stack for complete deployment of Metaflow (v2.2.5)
 
 Parameters:
   SagemakerInstance: 
@@ -59,6 +59,11 @@ Parameters:
     Default: 'true'
     AllowedValues: ['false', 'true']
     Description: 'Enable Sagemaker Notebooks'
+  IAMPartition:
+    Type: String
+    Default: 'aws'
+    AllowedValues: ['aws', 'aws-us-gov']
+    Description: 'IAM Partition (DO NOT CHANGE THIS UNLESS YOU HAVE A VERY SPECIFIC REASON)'
 
 Mappings:
   ServiceInfo:
@@ -86,6 +91,7 @@ Conditions:
   EnableAuth: !Equals [ !Ref APIBasicAuth, 'true']
   EnableRole: !Equals [ !Ref CustomRole, 'true']
   EnableSagemaker: !Equals [ !Ref EnableSagemaker, 'true']
+  IsGov: !Equals [ !Ref IAMPartition, 'aws-us-gov']
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -312,7 +318,7 @@ Resources:
             - 'sts:AssumeRole'
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+        - !Sub arn:${IAMPartition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -400,13 +406,13 @@ Resources:
             - Sid: CreateLogGroup
               Effect: Allow
               Action: logs:CreateLogGroup
-              Resource: !Join [ "", [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':*' ] ]
+              Resource: !Join [ "", [ !Sub 'arn:${IAMPartition}:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':*' ] ]
             - Sid: LogEvents
               Effect: Allow
               Action:
                 - logs:PutLogEvents
                 - logs:CreateLogStream
-              Resource: !Join [ "", [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/lambda/', !Ref 'AWS::StackName', '-migrate-db:*'] ]
+              Resource: !Join [ "", [ !Sub 'arn:${IAMPartition}:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/lambda/', !Ref 'AWS::StackName', '-migrate-db:*'] ]
         - PolicyName: VPC
           PolicyDocument:
             Version: '2012-10-17'
@@ -606,17 +612,17 @@ Resources:
               Action:
                 - logs:CreateLogStream
               Resource: 
-                - !Join [ "", [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/batch/job:log-stream:*' ] ]
-                - !Join [ "", [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/sagemaker/NotebookInstances:log-stream:*' ] ]
+                - !Join [ "", [ !Sub 'arn:${IAMPartition}:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/batch/job:log-stream:*' ] ]
+                - !Join [ "", [ !Sub 'arn:${IAMPartition}:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/sagemaker/NotebookInstances:log-stream:*' ] ]
             - Sid: LogEvents
               Effect: Allow
               Action:
                 - logs:PutLogEvents
                 - logs:GetLogEvents
               Resource: 
-                - !Join [ "", [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/sagemaker/NotebookInstances:log-stream:', !Ref 'AWS::StackName', '-NotebookInstance-', '{{resolve:secretsmanager:', !Ref RandomString, ':SecretString:password}}', '/jupyter.log' ] ]
-                - !Join [ "", [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/sagemaker/NotebookInstances:log-stream:', !Ref 'AWS::StackName', '-NotebookInstance-', '{{resolve:secretsmanager:', !Ref RandomString, ':SecretString:password}}', '/LifecycleConfigOnCreate' ] ]
-                - !Join [ "", [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/batch/job:log-stream:job-queue-' ] ]
+                - !Join [ "", [ !Sub 'arn:${IAMPartition}:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/sagemaker/NotebookInstances:log-stream:', !Ref 'AWS::StackName', '-NotebookInstance-', '{{resolve:secretsmanager:', !Ref RandomString, ':SecretString:password}}', '/jupyter.log' ] ]
+                - !Join [ "", [ !Sub 'arn:${IAMPartition}:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/sagemaker/NotebookInstances:log-stream:', !Ref 'AWS::StackName', '-NotebookInstance-', '{{resolve:secretsmanager:', !Ref RandomString, ':SecretString:password}}', '/LifecycleConfigOnCreate' ] ]
+                - !Join [ "", [ !Sub 'arn:${IAMPartition}:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/aws/batch/job:log-stream:job-queue-' ] ]
             - Sid: LogGroup
               Effect: Allow
               Action: 
@@ -637,8 +643,8 @@ Resources:
                 - "sagemaker:UpdateNotebookInstance"
                 - "sagemaker:CreatePresignedNotebookInstanceUrl"
               Resource:
-                - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/${AWS::StackName}*"
-                - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance-lifecycle-config/basic*"
+                - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/${AWS::StackName}*"
+                - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance-lifecycle-config/basic*"
         - PolicyName: CustomS3ListAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -694,7 +700,7 @@ Resources:
                   - "cloudformation:*Stack"
                   - "cloudformation:*ChangeSet"
                 Resource: 
-                  - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-*"
+                  - !Sub "arn:${IAMPartition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-*"
               - Effect: "Allow"
                 Action: 
                   - "s3:*Object"
@@ -709,19 +715,19 @@ Resources:
                   - "sagemaker:UpdateNotebookInstance"
                   - "sagemaker:CreatePresignedNotebookInstanceUrl"
                 Resource:
-                  - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/${AWS::StackName}-*"
-                  - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance-lifecycle-config/basic*"
+                  - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/${AWS::StackName}-*"
+                  - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance-lifecycle-config/basic*"
               - Effect: "Allow"
                 Action: 
                   - "iam:PassRole"
                 Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-*"
+                  - !Sub "arn:${IAMPartition}:iam::${AWS::AccountId}:role/${AWS::StackName}-*"
               - Effect: "Allow"
                 Action:
                   - "kms:Decrypt"
                   - "kms:Encrypt"
                 Resource:
-                  - !Sub "aws:aws:kms:${AWS::Region}:${AWS::AccountId}:key/"
+                  - !Sub "arn:${IAMPartition}:kms:${AWS::Region}:${AWS::AccountId}:key/"
         - PolicyName: BatchPerms
           PolicyDocument:
             Version: '2012-10-17'
@@ -741,7 +747,7 @@ Resources:
                 - "batch:SubmitJob"
               Resource:
                 - !Ref "JobQueue"
-                - !Sub arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*:*
+                - !Sub arn:${IAMPartition}:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*:*
         - PolicyName: CustomS3ListAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -757,7 +763,7 @@ Resources:
               Sid: GetLogs
               Effect: Allow
               Action: logs:GetLogEvents
-              Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+              Resource: !Sub arn:${IAMPartition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
         - PolicyName: AllowSagemaker
           PolicyDocument:
             Version: '2012-10-17'
@@ -765,11 +771,11 @@ Resources:
             - Sid: AllowSagemakerCreate
               Effect: Allow
               Action: sagemaker:CreateTrainingJob
-              Resource: !Sub arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
+              Resource: !Sub arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
             - Sid: AllowSagemakerDescribe
               Effect: Allow
               Action: sagemaker:DescribeTrainingJob
-              Resource: !Sub arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
+              Resource: !Sub arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
         - PolicyName: AllowStepFunctions
           PolicyDocument:
             Version: '2012-10-17'
@@ -788,7 +794,7 @@ Resources:
                 - "states:CreateStateMachine"
                 - "states:ListExecutions"
                 - "states:StopExecution"
-              Resource: !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:*'
+              Resource: !Sub 'arn:${IAMPartition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:*'
         - PolicyName: AllowEventBridge
           PolicyDocument:
             Version: '2012-10-17'
@@ -798,12 +804,12 @@ Resources:
                 Action:
                   - "events:PutTargets"
                   - "events:DisableRule"
-                Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*"
+                Resource: !Sub "arn:${IAMPartition}:events:${AWS::Region}:${AWS::AccountId}:rule/*"
               - Sid: PutRule
                 Effect: Allow
                 Action:
                   - "events:PutRule"
-                Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*"
+                Resource: !Sub "arn:${IAMPartition}:events:${AWS::Region}:${AWS::AccountId}:rule/*"
                 Condition:
                   "Null":
                     events:source: true
@@ -829,7 +835,7 @@ Resources:
                 Effect: Allow
                 Action:
                   - 'states:StartExecution'
-                Resource: !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:*'
+                Resource: !Sub 'arn:${IAMPartition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:*'
   StepFunctionsRole:
     Type: AWS::IAM::Role
     Properties:
@@ -863,7 +869,7 @@ Resources:
                 - "batch:SubmitJob"
               Resource:
                 - !Ref "JobQueue"
-                - !Sub arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*:*
+                - !Sub arn:${IAMPartition}:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*:*
         - PolicyName: CustomS3Access
           PolicyDocument:
             Version: '2012-10-17'
@@ -904,12 +910,12 @@ Resources:
                 Action:
                   - "events:PutTargets"
                   - "events:DescribeRule"
-                Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForBatchJobsRule"
+                Resource: !Sub "arn:${IAMPartition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForBatchJobsRule"
               - Sid: PutRule
                 Effect: Allow
                 Action:
                   - "events:PutRule"
-                Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForBatchJobsRule"
+                Resource: !Sub "arn:${IAMPartition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForBatchJobsRule"
                 Condition:
                   StringEquals: 
                     events:detail-type: "Batch Job State Change"
@@ -923,7 +929,7 @@ Resources:
                 - "dynamodb:PutItem"
                 - "dynamodb:GetItem"
                 - "dynamodb:UpdateItem"
-              Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${StepFunctionsStateDDB}
+              Resource: !Sub arn:${IAMPartition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${StepFunctionsStateDDB}
   BasicNotebookInstanceLifecycleConfig:
     Condition: 'EnableSagemaker'
     Type: "AWS::SageMaker::NotebookInstanceLifecycleConfig"
@@ -1021,11 +1027,11 @@ Resources:
             - Sid: AllowSagemakerCreate
               Effect: Allow
               Action: sagemaker:CreateTrainingJob
-              Resource: !Sub arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
+              Resource: !Sub arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
             - Sid: AllowSagemakerDescribe
               Effect: Allow
               Action: sagemaker:DescribeTrainingJob
-              Resource: !Sub arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
+              Resource: !Sub arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
             - Sid: AllowSagemakerDeploy
               Effect: Allow
               Action:
@@ -1036,9 +1042,9 @@ Resources:
                 - "sagemaker:DescribeEndpoint"
                 - "sagemaker:InvokeEndpoint"
               Resource:
-                - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint/*"
-                - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:model/*"
-                - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint-config/*"
+                - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint/*"
+                - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:model/*"
+                - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint-config/*"
         - PolicyName: IAM_PASS_ROLE
           PolicyDocument:
             Version: '2012-10-17'
@@ -1060,7 +1066,7 @@ Resources:
                 - "dynamodb:PutItem"
                 - "dynamodb:GetItem"
                 - "dynamodb:UpdateItem"
-              Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${StepFunctionsStateDDB}
+              Resource: !Sub arn:${IAMPartition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${StepFunctionsStateDDB}
   BatchExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1212,6 +1218,9 @@ Resources:
     DependsOn: VpcLink
     Type: 'AWS::ApiGateway::RestApi'
     Properties:
+      EndpointConfiguration:
+        Types:
+          - !If [ IsGov, 'REGIONAL', 'EDGE' ]
       Name: !Join ['-', [!Ref 'AWS::StackName', 'api'] ]
   ApiResource:
     Type: 'AWS::ApiGateway::Resource'


### PR DESCRIPTION
**Notable user-facing Changes**
The addition of a new Parameter called "IAM Partition".  The default will support most users.  Users in non-standard AWS partitions (notably Gov-Cloud) will need to change their partition value (there's only one other available option in the template, so it's an easy choice) or else the template will fail to deploy.

**Notable Changes for non-Gov Users**
None.  Deployment shouldn't change for users in the standard AWS IAM partitions unless they actively change the partition from the default.

**Other notes**
_EDGE_ API types for API Gateway are unsupported in Gov Cloud.  There's a conditional in this new template that will change the API-type for effected users to _REGIONAL_.

**Did you test this, Rob?**
Yup.  Tested with Batch and Step Functions in both standard and Gov cloud partitions.