### PR TITLE
Update description for MinVCPUBatch

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -32,7 +32,7 @@ Parameters:
     MinValue: 0
     MaxValue: 16
     AllowedValues: [0,2,4,8,16]
-    Description: 'Maximum VCPUs for Batch Compute Environment [0-16]'
+    Description: 'Minimum VCPUs for Batch Compute Environment [0-16]'
   DesiredVCPUBatch: 
     Type: Number
     Default: 8


### PR DESCRIPTION
The MinVCPUBatch had 'Maximum' instead of 'Minimum' in description