### PR TITLE
AWS Batch Fargate integration

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -32,14 +32,14 @@ Parameters:
     MinValue: 0
     MaxValue: 16
     AllowedValues: [0,2,4,8,16]
-    Description: 'Minimum VCPUs for Batch Compute Environment [0-16]'
+    Description: 'Minimum VCPUs for Batch Compute Environment [0-16] for EC2 Batch Compute Environment (ignored for Fargate)'
   DesiredVCPUBatch: 
     Type: Number
     Default: 8
     MinValue: 0
     MaxValue: 16
     AllowedValues: [0,2,4,8,16]
-    Description: 'Desired Starting VCPUs for Batch Compute Environment [0-16]'
+    Description: 'Desired Starting VCPUs for Batch Compute Environment [0-16] for EC2 Batch Compute Environment (ignored for Fargate)'
   ComputeEnvInstanceTypes: 
     Type: CommaDelimitedList
     Default: "c4.large,c4.xlarge,c4.2xlarge,c4.4xlarge,c4.8xlarge"
@@ -95,7 +95,7 @@ Mappings:
 Conditions:
   EnableAuth: !Equals [ !Ref APIBasicAuth, 'true']
   EnableRole: !Equals [ !Ref CustomRole, 'true']
-  BatchFargate: !Equals [ !Ref BatchType, 'fargate']
+  EnableFargateOnBatch: !Equals [ !Ref BatchType, 'fargate']
   EnableSagemaker: !Equals [ !Ref EnableSagemaker, 'true']
   IsGov: !Equals [ !Ref IAMPartition, 'aws-us-gov']
 Resources:
@@ -1211,14 +1211,14 @@ Resources:
         MaxvCpus: !Ref MaxVCPUBatch
         SecurityGroupIds:
           - !GetAtt VPC.DefaultSecurityGroup
-        Type: !If [BatchFargate, 'FARGATE', 'EC2']
+        Type: !If [EnableFargateOnBatch, 'FARGATE', 'EC2']
         Subnets:
           - !Ref Subnet1
           - !Ref Subnet2
-        MinvCpus: !If [BatchFargate, !Ref AWS::NoValue, !Ref MinVCPUBatch]
-        InstanceRole: !If [BatchFargate, !Ref AWS::NoValue, !GetAtt 'ECSInstanceProfile.Arn']
-        InstanceTypes: !If [BatchFargate, !Ref AWS::NoValue, !Ref ComputeEnvInstanceTypes]
-        DesiredvCpus: !If [BatchFargate, !Ref AWS::NoValue, !Ref DesiredVCPUBatch]
+        MinvCpus: !If [EnableFargateOnBatch, !Ref AWS::NoValue, !Ref MinVCPUBatch]
+        InstanceRole: !If [EnableFargateOnBatch, !Ref AWS::NoValue, !GetAtt 'ECSInstanceProfile.Arn']
+        InstanceTypes: !If [EnableFargateOnBatch, !Ref AWS::NoValue, !Ref ComputeEnvInstanceTypes]
+        DesiredvCpus: !If [EnableFargateOnBatch, !Ref AWS::NoValue, !Ref DesiredVCPUBatch]
       State: ENABLED
   JobQueue:
     DependsOn: ComputeEnvironment

--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Stack for complete deployment of Metaflow (last-updated-date 12/02/2020)
+Description: Stack for complete deployment of Metaflow (last-updated-date 02/09/2021)
 
 Parameters:
   SagemakerInstance: 

--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -59,6 +59,11 @@ Parameters:
     Default: 'true'
     AllowedValues: ['false', 'true']
     Description: 'Enable Sagemaker Notebooks'
+  BatchType:
+    Type: String
+    Default: 'ec2'
+    AllowedValues: ['ec2', 'fargate']
+    Description: 'AWS Batch Compute Type'
   IAMPartition:
     Type: String
     Default: 'aws'
@@ -90,6 +95,7 @@ Mappings:
 Conditions:
   EnableAuth: !Equals [ !Ref APIBasicAuth, 'true']
   EnableRole: !Equals [ !Ref CustomRole, 'true']
+  BatchFargate: !Equals [ !Ref BatchType, 'fargate']
   EnableSagemaker: !Equals [ !Ref EnableSagemaker, 'true']
   IsGov: !Equals [ !Ref IAMPartition, 'aws-us-gov']
 Resources:
@@ -1067,6 +1073,16 @@ Resources:
                 - "dynamodb:GetItem"
                 - "dynamodb:UpdateItem"
               Resource: !Sub arn:${IAMPartition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${StepFunctionsStateDDB}
+        - PolicyName: Cloudwatch
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Sid: AllowPutLogs
+              Effect: Allow
+              Action:
+                - 'logs:CreateLogStream'
+                - 'logs:PutLogEvents'
+              Resource: '*'
   BatchExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1195,14 +1211,14 @@ Resources:
         MaxvCpus: !Ref MaxVCPUBatch
         SecurityGroupIds:
           - !GetAtt VPC.DefaultSecurityGroup
-        Type: EC2
+        Type: !If [BatchFargate, 'FARGATE', 'EC2']
         Subnets:
           - !Ref Subnet1
           - !Ref Subnet2
-        MinvCpus: !Ref MinVCPUBatch
-        InstanceRole: !GetAtt 'ECSInstanceProfile.Arn'
-        InstanceTypes: !Ref ComputeEnvInstanceTypes
-        DesiredvCpus: !Ref DesiredVCPUBatch
+        MinvCpus: !If [BatchFargate, !Ref AWS::NoValue, !Ref MinVCPUBatch]
+        InstanceRole: !If [BatchFargate, !Ref AWS::NoValue, !GetAtt 'ECSInstanceProfile.Arn']
+        InstanceTypes: !If [BatchFargate, !Ref AWS::NoValue, !Ref ComputeEnvInstanceTypes]
+        DesiredvCpus: !If [BatchFargate, !Ref AWS::NoValue, !Ref DesiredVCPUBatch]
       State: ENABLED
   JobQueue:
     DependsOn: ComputeEnvironment

--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -746,6 +746,7 @@ Resources:
                 - "batch:DescribeJobDefinitions"
                 - "batch:DescribeJobQueues"
                 - "batch:RegisterJobDefinition"
+                - "batch:DescribeComputeEnvironments"
               Resource: '*'
             - Sid: DefinitionsPermissions
               Effect: Allow


### PR DESCRIPTION
**User-facing changes**: A new "BatchType" parameter that's set to 'ec2' by default.  Users can optionally set this parameter to 'fargate' which will alter the AWS Batch Compute Environment that's created to 'FARGATE'.

**Considerations**: Fundamentally, this just overlays a conditional for the "Type" parameter of the AWS Compute Environment's "ComputeResources" grouping to change it between EC2 and Fargate.  Additionally, in order to enable Fargate, a similar mechanism needs to depopulate the values for MinvCpus, DesiredVCpus, InstanceTypes, and InstanceRole.  All of those parameters will be ignored if 'fargate' is selected, even if set by the user.  Lastly, in order to facilitate logging, a CreateLogStream and PutLogs permission was added to the ECS Task role.  This wasn't required previously, as the instance itself logged on behalf of the container.