### PR TITLE
Allow to specify an additional policy ARN to attach to Batch worker nodes

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -72,7 +72,7 @@ Parameters:
   AdditionalWorkerPolicyArn:
     Type: String
     Default: ''
-    Description: 'Additional IAM Policy ARN to attach to nodes executing Metaflow step code.'
+    Description: 'Additional IAM Policy ARN to attach to Batch Compute Environment.'
 
 Mappings:
   ServiceInfo:

--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -69,6 +69,10 @@ Parameters:
     Default: 'aws'
     AllowedValues: ['aws', 'aws-us-gov']
     Description: 'IAM Partition (Select aws-us-gov for AWS GovCloud, otherwise leave as is)'
+  AdditionalWorkerPolicyArn:
+    Type: String
+    Default: ''
+    Description: 'Additional IAM Policy ARN to attach to nodes executing Metaflow step code.'
 
 Mappings:
   ServiceInfo:
@@ -98,6 +102,7 @@ Conditions:
   EnableFargateOnBatch: !Equals [ !Ref BatchType, 'fargate']
   EnableSagemaker: !Equals [ !Ref EnableSagemaker, 'true']
   IsGov: !Equals [ !Ref IAMPartition, 'aws-us-gov']
+  EnableAddtionalWorkerPolicy: !Not [ !Equals [ !Ref AdditionalWorkerPolicyArn, ''] ]
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -996,6 +1001,11 @@ Resources:
           Action:
             - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !If
+          - EnableAddtionalWorkerPolicy
+          - !Ref 'AdditionalWorkerPolicyArn'
+          - !Ref AWS::NoValue
       Policies:
         - PolicyName: CustomS3ListBatch
           PolicyDocument:


### PR DESCRIPTION
Sometimes your Step code needs to access additional AWS services, not just what Metaflow uses by itself. This PR adds an additional, optional parameter to the CFN template, that allows you to specify one additional policy to attach. This could be either AWS Managed or Customer Managed standalone IAM policy.