### PR TITLE
Remove provider spec from infra module

### DIFF
--- a/aws/terraform/infra/main.tf
+++ b/aws/terraform/infra/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.aws_region
-}
-
 module "common_vars" {
   source = "../modules/common"
 


### PR DESCRIPTION
This messes up provider settings if you want to use `infra` as a module elsewhere. For example, in my case I have multiple providers for a cross-account config, and `infra` picks up the wrong one

See https://www.terraform.io/docs/language/modules/develop/providers.html
> A module intended to be called by one or more other modules must not contain any provider blocks