### PR TITLE
Remove prevent_destroy on S3 bucket

### DIFF
--- a/aws/terraform/modules/metaflow/modules/datastore/s3.tf
+++ b/aws/terraform/modules/metaflow/modules/datastore/s3.tf
@@ -16,10 +16,6 @@ resource "aws_s3_bucket" "this" {
       Metaflow = "true"
     }
   )
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {


### PR DESCRIPTION
I understand this was introduced for parity with CFN but unlike CFN "Retain" policy, setting this on S3 bucket resource effectively prevents the module user from being able to destroy _anything_ (without forking the module and removing prevent_destroy). While it is set, Terraform will refuse to delete the bucket and transitively anything else.

```
│ Resource module.metaflow.module.metaflow-datastore.aws_s3_bucket.this has lifecycle.prevent_destroy set, but the plan calls for this resource to be destroyed. To avoid this
│ error and continue with the plan, either disable lifecycle.prevent_destroy or reduce the scope of the plan using the -target flag.
```

You can probably technically delete other stuff using `-target` but it is a huge pain